### PR TITLE
fix json encoding flags

### DIFF
--- a/src/Worldline/Requests/Request.php
+++ b/src/Worldline/Requests/Request.php
@@ -75,7 +75,7 @@ class Request
 
         // dont include the digest header for empty body
         if (!empty($body)) {
-            $headers['Digest'] = 'SHA-256='.base64_encode(hash('sha256', json_encode($this->body), true));
+            $headers['Digest'] = 'SHA-256='.base64_encode(hash('sha256', $body, true));
         }
 
         $request = new \GuzzleHttp\Psr7\Request(

--- a/src/Worldline/Resources/RequestSignature.php
+++ b/src/Worldline/Resources/RequestSignature.php
@@ -40,7 +40,7 @@ class RequestSignature
 
         // dont include the digest header for empty body
         if (!empty($body)) {
-            $headers['digest'] = 'SHA-256='.base64_encode(hash('sha256', json_encode($body), true));
+            $headers['digest'] = 'SHA-256='.base64_encode(hash('sha256', json_encode($body, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES), true));
         }
 
         $headers = array_merge($this->headers, $headers);


### PR DESCRIPTION
This fixes failing calls when special characters are used in transaction requests